### PR TITLE
Fix/compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,16 @@ set(PCL_CATKIN_INCLUDE ${CATKIN_DEVEL_PREFIX}/include/pcl-1.8)
 file(MAKE_DIRECTORY ${PCL_CATKIN_INCLUDE})
 
 if(NOT CMAKE_BUILD_TYPE)
-	MESSAGE(FATAL_ERROR "CMAKE_BUILD_TYPE must not be empty!")
+  MESSAGE(FATAL_ERROR "CMAKE_BUILD_TYPE must not be empty!")
 endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} UC_BUILD_TYPE)
+
+# PCL uses -march=native which can be dangerous to use together with Eigen 3.3
+# as this can introduce different vectorization settings in different parts
+# of the code. So we manually set the compiler flags here to avoid this issue.
+# Some flags that PCL defines per default.
+SET(PCL_CXX_FLAGS "-Wall -Wextra -Wno-unknown-pragmas -fno-strict-aliasing -Wno-format-extra-args -Wno-sign-compare -Wno-invalid-offsetof -Wno-conversion -msse4.2 -mfpmath=sse -Wabi -pthread")
+SET(PCL_CXX_FLAGS "${PCL_CXX_FLAGS} -std=c++11 -mssse3")
 
 ExternalProject_Add(pcl_src
   GIT_REPOSITORY  https://github.com/ethz-asl/pcl
@@ -21,7 +28,8 @@ ExternalProject_Add(pcl_src
   UPDATE_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}
              -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-             "-DCMAKE_CXX_FLAGS_${UC_BUILD_TYPE}=${CMAKE_CXX_FLAGS_${UC_BUILD_TYPE}} --std=c++0x"
+             -DCMAKE_CXX_FLAGS:STRING=${PCL_CXX_FLAGS}
+             "-DCMAKE_CXX_FLAGS_${UC_BUILD_TYPE}=${CMAKE_CXX_FLAGS_${UC_BUILD_TYPE}} ${PCL_CXX_FLAGS}"
 )
 
 cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,12 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} UC_BUILD_TYPE)
 # PCL uses -march=native which can be dangerous to use together with Eigen 3.3
 # as this can introduce different vectorization settings in different parts
 # of the code. So we manually set the compiler flags here to avoid this issue.
-# Some flags that PCL defines per default.
-SET(PCL_CXX_FLAGS "-Wall -Wextra -Wno-unknown-pragmas -fno-strict-aliasing -Wno-format-extra-args -Wno-sign-compare -Wno-invalid-offsetof -Wno-conversion -msse4.2 -mfpmath=sse -Wabi -pthread")
-SET(PCL_CXX_FLAGS "${PCL_CXX_FLAGS} -std=c++11 -mssse3")
+include("${CMAKE_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
+PCL_CHECK_FOR_SSE()
+
+# Flags that PCL defines by default, see https://github.com/PointCloudLibrary/pcl/blob/master/CMakeLists.txt#L112
+SET(PCL_CXX_FLAGS "-Wall -Wextra -Wno-unknown-pragmas -fno-strict-aliasing -Wno-format-extra-args -Wno-sign-compare -Wno-invalid-offsetof -Wno-conversion ${SSE_FLAGS} -Wabi")
+SET(PCL_CXX_FLAGS "${PCL_CXX_FLAGS} -std=c++11")
 
 ExternalProject_Add(pcl_src
   GIT_REPOSITORY  https://github.com/ethz-asl/pcl

--- a/cmake/pcl_find_sse.cmake
+++ b/cmake/pcl_find_sse.cmake
@@ -1,0 +1,191 @@
+# Adapted from https://github.com/PointCloudLibrary/pcl/blob/master/cmake/pcl_find_sse.cmake
+
+###############################################################################
+# Check for the presence of SSE and figure out the flags to use for it.
+macro(PCL_CHECK_FOR_SSE)
+    set(SSE_FLAGS)
+    set(SSE_DEFINITIONS)
+
+    # Unfortunately we need to check for SSE to enable "-mfpmath=sse" alongside 
+    # "-march=native". The reason for this is that by default, 32bit architectures
+    # tend to use the x87 FPU (which has 80 bit internal precision), thus leading
+    # to different results than 64bit architectures which are using SSE2 (64 bit internal
+    # precision). One solution would be to use "-ffloat-store" on 32bit (see 
+    # http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html), but that slows code down,
+    # so the preferred solution is to try "-mpfmath=sse" first.
+    include(CheckCXXSourceRuns)
+    set(CMAKE_REQUIRED_FLAGS)
+
+    check_cxx_source_runs("
+        #include <mm_malloc.h>
+        int main()
+        {
+          void* mem = _mm_malloc (100, 16);
+          return 0;
+        }"
+        HAVE_MM_MALLOC)
+
+    check_cxx_source_runs("
+        #include <stdlib.h>
+        int main()
+        {
+          void* mem;
+          return posix_memalign (&mem, 16, 100);
+        }"
+        HAVE_POSIX_MEMALIGN)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-msse4.2")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+
+    check_cxx_source_runs("
+        #include <emmintrin.h>
+        #include <nmmintrin.h>
+        int main ()
+        {
+          long long a[2] = {  1, 2 };
+          long long b[2] = { -1, 3 };
+          long long c[2];
+          __m128i va = _mm_loadu_si128 ((__m128i*)a);
+          __m128i vb = _mm_loadu_si128 ((__m128i*)b);
+          __m128i vc = _mm_cmpgt_epi64 (va, vb);
+          _mm_storeu_si128 ((__m128i*)c, vc);
+          if (c[0] == -1LL && c[1] == 0LL)
+            return (0);
+          else
+            return (1);
+        }"
+        HAVE_SSE4_2_EXTENSIONS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-msse4.1")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+
+    check_cxx_source_runs("
+        #include <smmintrin.h>
+        int main ()
+        {
+          __m128 a, b;
+          float vals[4] = {1, 2, 3, 4};
+          const int mask = 123;
+          a = _mm_loadu_ps (vals);
+          b = a;
+          b = _mm_dp_ps (a, a, mask);
+          _mm_storeu_ps (vals,b);
+          return (0);
+        }"
+        HAVE_SSE4_1_EXTENSIONS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-mssse3")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+
+    check_cxx_source_runs("
+        #include <tmmintrin.h>
+        int main ()
+        {
+          __m128i a, b;
+          int vals[4] = {-1, -2, -3, -4};
+          a = _mm_loadu_si128 ((const __m128i*)vals);
+          b = _mm_abs_epi32 (a);
+          _mm_storeu_si128 ((__m128i*)vals, b);
+          return (0);
+        }"
+        HAVE_SSSE3_EXTENSIONS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-msse3")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+
+    check_cxx_source_runs("
+        #include <pmmintrin.h>
+        int main ()
+        {
+            __m128d a, b;
+            double vals[2] = {0};
+            a = _mm_loadu_pd (vals);
+            b = _mm_hadd_pd (a,a);
+            _mm_storeu_pd (vals, b);
+            return (0);
+        }"
+        HAVE_SSE3_EXTENSIONS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-msse2")
+    elseif(MSVC AND NOT CMAKE_CL_64)
+        set(CMAKE_REQUIRED_FLAGS "/arch:SSE2")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+    
+    check_cxx_source_runs("
+        #include <emmintrin.h>
+        int main ()
+        {
+            __m128d a, b;
+            double vals[2] = {0};
+            a = _mm_loadu_pd (vals);
+            b = _mm_add_pd (a,a);
+            _mm_storeu_pd (vals,b);
+            return (0);
+        }"
+        HAVE_SSE2_EXTENSIONS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        set(CMAKE_REQUIRED_FLAGS "-msse")
+    elseif(MSVC AND NOT CMAKE_CL_64)
+        set(CMAKE_REQUIRED_FLAGS "/arch:SSE")
+    endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+
+    check_cxx_source_runs("
+        #include <xmmintrin.h>
+        int main ()
+        {
+            __m128 a, b;
+            float vals[4] = {0};
+            a = _mm_loadu_ps (vals);
+            b = a;
+            b = _mm_add_ps (a,b);
+            _mm_storeu_ps (vals,b);
+            return (0);
+        }"
+        HAVE_SSE_EXTENSIONS)
+
+    set(CMAKE_REQUIRED_FLAGS)
+
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+        if(HAVE_SSE4_2_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -msse4.2 -mfpmath=sse")
+        elseif(HAVE_SSE4_1_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -msse4.1 -mfpmath=sse")
+        elseif(HAVE_SSSE3_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -mssse3 -mfpmath=sse")
+        elseif(HAVE_SSE3_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -msse3 -mfpmath=sse")
+        elseif(HAVE_SSE2_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -msse2 -mfpmath=sse")
+        elseif(HAVE_SSE_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} -msse -mfpmath=sse")
+        else()
+            # Setting -ffloat-store to alleviate 32bit vs 64bit discrepancies on non-SSE
+            # platforms.
+            set(SSE_FLAGS "-ffloat-store")
+        endif()
+    elseif(MSVC AND NOT CMAKE_CL_64)
+        if(HAVE_SSE2_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} /arch:SSE2")
+        elseif(HAVE_SSE_EXTENSIONS)
+            SET(SSE_FLAGS "${SSE_FLAGS} /arch:SSE")
+        endif(HAVE_SSE2_EXTENSIONS)
+    endif()
+
+    if(MSVC)
+        if(HAVE_SSSE3_EXTENSIONS)
+            SET(SSE_DEFINITIONS "${SSE_DEFINITIONS} -D__SSSE3__")
+        endif()
+        if(HAVE_SSE2_EXTENSIONS)
+            SET(SSE_DEFINITIONS "${SSE_DEFINITIONS} -D__SSE2__")
+        endif()
+        if(HAVE_SSE_EXTENSIONS)
+            SET(SSE_DEFINITIONS "${SSE_DEFINITIONS} -D__SSE__")
+        endif()
+    endif()
+endmacro(PCL_CHECK_FOR_SSE)


### PR DESCRIPTION
Define compile flags for PCL to avoid it being compiled with -march=native.

Explanation:
-march=native enables all vectorization commands (SSE, AVX, etc.). Unlike the old Eigen 3.2, Eigen 3.3 now supports AVX instructions which means that if you compile libraries with different flags, some alignment assumptions are not valid anymore and Eigen will crash in the most unexpected ways. (Usually it means that part of the code expects 32 byte-aligned matrices for AVX whereas the matrix is only 16 byte-aligned because it was only compiled with SSE enabled.)

Also see https://github.com/ethz-asl/thirdparty_submodules/pull/121