### PR TITLE
Fix include in CMakeLists.txt

### DIFF
--- a/pcl_catkin/CMakeLists.txt
+++ b/pcl_catkin/CMakeLists.txt
@@ -19,7 +19,7 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} UC_BUILD_TYPE)
 # PCL uses -march=native which can be dangerous to use together with Eigen 3.3
 # as this can introduce different vectorization settings in different parts
 # of the code. So we manually set the compiler flags here to avoid this issue.
-include("${CMAKE_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
 PCL_CHECK_FOR_SSE()
 
 # Flags that PCL defines by default, see https://github.com/PointCloudLibrary/pcl/blob/master/CMakeLists.txt#L112


### PR DESCRIPTION
@ffurrer @floriantschopp 
I guys, I think the include path should start from the directory currently being processed ($CMAKE_CURRENT_SOURCE_DIR), and not from top level of the source tree ($CMAKE_SOURCE_DIR). 